### PR TITLE
Center Header and bring in additional header menu buttons

### DIFF
--- a/app/components/Header.jsx
+++ b/app/components/Header.jsx
@@ -11,8 +11,8 @@ export function Header({header, isLoggedIn, cart, publicStoreDomain}) {
   const {shop, menu} = header;
   return (
     <header className="header">
-      <NavLink prefetch="intent" to="/" style={activeLinkStyle} end>
-        <strong>{"Flashback Thrift"}</strong>
+      <NavLink prefetch="intent" to="/" className="title">
+        {"Flashback Thrift"}
       </NavLink>
       <div className="inline-components">
         <HeaderMenu

--- a/app/components/Header.jsx
+++ b/app/components/Header.jsx
@@ -43,6 +43,7 @@ export function HeaderMenu({
   viewport,
   publicStoreDomain,
 }) {
+  console.log("myMenu: ", menu)
   const className = `header-menu-${viewport}`;
 
   function closeAside(event) {

--- a/app/components/Header.jsx
+++ b/app/components/Header.jsx
@@ -6,7 +6,6 @@ import {useAside} from '~/components/Aside';
 /**
  * @param {HeaderProps}
  */
-// This is the flashback thrift logo
 export function Header({header, isLoggedIn, cart, publicStoreDomain}) {
   const {shop, menu} = header;
   return (
@@ -36,14 +35,12 @@ export function Header({header, isLoggedIn, cart, publicStoreDomain}) {
  *   publicStoreDomain: HeaderProps['publicStoreDomain'];
  * }}
  */
-// Header Menu is the home catalog content shit
 export function HeaderMenu({
   menu,
   primaryDomainUrl,
   viewport,
   publicStoreDomain,
 }) {
-  console.log("myMenu: ", menu)
   const className = `header-menu-${viewport}`;
 
   function closeAside(event) {

--- a/app/components/Header.jsx
+++ b/app/components/Header.jsx
@@ -6,6 +6,7 @@ import {useAside} from '~/components/Aside';
 /**
  * @param {HeaderProps}
  */
+// This is the flashback thrift logo
 export function Header({header, isLoggedIn, cart, publicStoreDomain}) {
   const {shop, menu} = header;
   return (
@@ -13,13 +14,16 @@ export function Header({header, isLoggedIn, cart, publicStoreDomain}) {
       <NavLink prefetch="intent" to="/" style={activeLinkStyle} end>
         <strong>{"Flashback Thrift"}</strong>
       </NavLink>
-      <HeaderMenu
-        menu={menu}
-        viewport="desktop"
-        primaryDomainUrl={header.shop.primaryDomain.url}
-        publicStoreDomain={publicStoreDomain}
-      />
-      <HeaderCtas isLoggedIn={isLoggedIn} cart={cart} />
+      <div className="inline-components">
+        <HeaderMenu
+          menu={menu}
+          viewport="desktop"
+          primaryDomainUrl={header.shop.primaryDomain.url}
+          publicStoreDomain={publicStoreDomain}
+        />
+        {/* Commented out below until i figure out how where to put login/cart icons */}
+        {/* <HeaderCtas isLoggedIn={isLoggedIn} cart={cart} /> */}
+      </div>
     </header>
   );
 }
@@ -32,6 +36,7 @@ export function Header({header, isLoggedIn, cart, publicStoreDomain}) {
  *   publicStoreDomain: HeaderProps['publicStoreDomain'];
  * }}
  */
+// Header Menu is the home catalog content shit
 export function HeaderMenu({
   menu,
   primaryDomainUrl,

--- a/app/components/PageLayout.jsx
+++ b/app/components/PageLayout.jsx
@@ -20,6 +20,7 @@ export function PageLayout({
   isLoggedIn,
   publicStoreDomain,
 }) {
+  console.log("headerValue", header)
   return (
     <Aside.Provider>
       <CartAside cart={cart} />

--- a/app/components/PageLayout.jsx
+++ b/app/components/PageLayout.jsx
@@ -20,7 +20,6 @@ export function PageLayout({
   isLoggedIn,
   publicStoreDomain,
 }) {
-  console.log("headerValue", header)
   return (
     <Aside.Provider>
       <CartAside cart={cart} />

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -187,7 +187,6 @@ button.reset:hover:not(:has(> *)) {
   @media (min-width: 45em) {
     display: flex;
     grid-gap: 1rem;
-    /* margin-left: 3rem; Remove this..?*/
   }
 }
 

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -148,14 +148,21 @@ button.reset:hover:not(:has(> *)) {
 * --------------------------------------------------
 */
 .header {
-  align-items: center;
   background: #fff;
   display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
   height: var(--header-height);
   padding: 0 1rem;
   position: sticky;
   top: 0;
   z-index: 1;
+}
+
+.inline-components {
+  display: flex;
+  align-items: center;
 }
 
 .header-menu-mobile-toggle {
@@ -176,7 +183,7 @@ button.reset:hover:not(:has(> *)) {
   @media (min-width: 45em) {
     display: flex;
     grid-gap: 1rem;
-    margin-left: 3rem;
+    /* margin-left: 3rem; Remove this..?*/
   }
 }
 

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -147,6 +147,10 @@ button.reset:hover:not(:has(> *)) {
 * components/Header
 * --------------------------------------------------
 */
+.title {
+  font-size: 2rem;
+}
+
 .header {
   background: #fff;
   display: flex;


### PR DESCRIPTION
Updates to the header, will add sign in and cart buttons back in a separate PR 
![image](https://github.com/user-attachments/assets/5ebd72e5-2718-4873-8b9e-aa3b474ab840)


The additional header menu's were brought in through the shopify storefront UX. The new tabs are linked to random arbitrary searches. In the future they will be tied to their respective content.
![image](https://github.com/user-attachments/assets/d4f85cf3-f359-4d6c-8771-bee6c8859703)
